### PR TITLE
Added updateUserRole API to the service

### DIFF
--- a/src/controllers/system-setting-controllers/getUserRole.controller.js
+++ b/src/controllers/system-setting-controllers/getUserRole.controller.js
@@ -78,8 +78,6 @@ const getAllUserRoles = async () => {
         roleDesc: roleDtl.role_desc,
         active: roleDtl.is_active,
         default: roleDtl.is_default,
-        createdDate: convertToNativeTimeZone(roleDtl.created_date),
-        modifiedDate: convertToNativeTimeZone(roleDtl.modified_date),
       };
     });
 

--- a/src/controllers/system-setting-controllers/index.js
+++ b/src/controllers/system-setting-controllers/index.js
@@ -2,10 +2,12 @@
 
 import { verifyUserRoleExist, registerNewUserRole } from './registerUserRole.controller.js';
 import { getRoleById, getAllUserRoles } from './getUserRole.controller.js';
+import { updateUserRole } from './updateUserRole.controller.js';
 
 export default {
   verifyUserRoleExist,
   registerNewUserRole,
   getRoleById,
   getAllUserRoles,
+  updateUserRole,
 };

--- a/src/controllers/system-setting-controllers/registerUserRole.controller.js
+++ b/src/controllers/system-setting-controllers/registerUserRole.controller.js
@@ -53,7 +53,7 @@ const registerNewUserRole = async (payload) => {
       log.info('Call db query to deactivate existing default role');
       const currentActiveRole = await getDefaultRole();
       if (currentActiveRole.rowCount === 1) {
-        deactivateRole(currentActiveRole.rows[0].id);
+        await deactivateRole(currentActiveRole.rows[0].id);
       }
     }
 

--- a/src/controllers/system-setting-controllers/updateUserRole.controller.js
+++ b/src/controllers/system-setting-controllers/updateUserRole.controller.js
@@ -1,0 +1,85 @@
+'use strict';
+
+import { convertPrettyStringToId, logger } from 'finance-lib';
+import { getRoleById } from './getUserRole.controller.js';
+import { deactivateRole, getDefaultRole, updateUserRoleById } from '../../db/system.db.js';
+
+const log = logger('Controller: update-user-role');
+
+const updateUserRole = async (userId, roleId, roleDtl, payload) => {
+  try {
+    log.info('Call controller function to update user role in system');
+    if (roleDtl.default && (payload.active !== null && payload.active !== undefined) && !payload.active) {
+      log.error('Cannot deactivate default user role');
+      return {
+        status: 400,
+        message: 'Cannot deactivate default user role',
+        data: [roleDtl],
+        errors: [],
+        stack: 'updateUserRole function call',
+        isValid: false,
+      };
+    }
+
+    if ((payload.active !== null && payload.active !== undefined) && (payload.default !== null && payload.default !== undefined) && !payload.active && payload.default) {
+      log.error('Cannot make user role default and deactivate it.');
+      return {
+        status: 400,
+        message: 'Cannot make user role default and deactivate the same.',
+        data: [roleDtl],
+        errors: [],
+        stack: 'updateUserRole function call',
+        isValid: false,
+      };
+    }
+
+    const providedDefaultVal = payload.default || false;
+    if (providedDefaultVal && !roleDtl.default) {
+      log.info('Call db query to deactivate existing default role');
+      const currentActiveRole = await getDefaultRole();
+      if (currentActiveRole.rowCount === 1) {
+        await deactivateRole(currentActiveRole.rows[0].id);
+      }
+    }
+
+    userId = convertPrettyStringToId(userId);
+    const body = {
+      id: convertPrettyStringToId(roleId),
+      roleDesc: payload.roleDesc || roleDtl.roleDesc,
+      active: roleDtl.active,
+      default: roleDtl.default,
+    };
+
+    if (payload.active !== null && payload.active !== undefined) {
+      body['active'] = payload.active;
+    }
+    if (payload.default !== null && payload.default !== undefined) {
+      body['default'] = payload.default;
+    }
+
+    log.info('Call db query to update user role info');
+    await updateUserRoleById(userId, body);
+    let updatedRoleDtl = await getRoleById(body.id);
+    updatedRoleDtl = updatedRoleDtl.data;
+
+    log.success('User role info updated successfully in system');
+    return {
+      status: 200,
+      message: 'User role updated successfully',
+      data: updatedRoleDtl,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while updating user role in system');
+    return {
+      status: 500,
+      message: 'An error occurred while updating user role info in system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { updateUserRole };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -15,7 +15,7 @@ import {
   logoutUser,
 } from './user.db.js';
 
-import { isRoleAvailable, getDefaultRole, deactivateRole, registerNewRole, getUserRoleById, getUserRoles } from './system.db.js';
+import { isRoleAvailable, getDefaultRole, deactivateRole, registerNewRole, getUserRoleById, getUserRoles, updateUserRoleById } from './system.db.js';
 
 export {
   fetchDefaultUserRole,
@@ -36,4 +36,5 @@ export {
   registerNewRole,
   getUserRoleById,
   getUserRoles,
+  updateUserRoleById,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -12,7 +12,7 @@ const isRoleAvailable = async (roleCd) => {
 };
 
 const getDefaultRole = async () => {
-  const query = `SELECT ID FROM USER_ROLE WHERE IS_DELETED = false AND IS_DEFAULT = true;`;
+  const query = `SELECT ID FROM USER_ROLE WHERE IS_DELETED = false AND IS_ACTIVE = true AND IS_DEFAULT = true;`;
   return exec(query);
 };
 
@@ -41,10 +41,16 @@ const getUserRoleById = async (roleId) => {
 };
 
 const getUserRoles = async () => {
-  const query = `SELECT ID, ROLE_CD, ROLE_DESC, IS_ACTIVE, IS_DEFAULT, CREATED_DATE, MODIFIED_DATE
-        FROM USER_ROLE
-        WHERE IS_DELETED = false`;
+  const query = `SELECT ID, ROLE_CD, ROLE_DESC, IS_ACTIVE, IS_DEFAULT FROM USER_ROLE WHERE IS_DELETED = false`;
   return exec(query);
 };
 
-export { isRoleAvailable, getDefaultRole, deactivateRole, registerNewRole, getUserRoleById, getUserRoles };
+const updateUserRoleById = async (userId, payload) => {
+  const query = `UPDATE USER_ROLE SET ROLE_DESC = ?, IS_ACTIVE = ?, IS_DEFAULT = ?, MODIFIED_BY = ?
+    WHERE ID = ? AND IS_DELETED = false;`;
+  const params = [payload.roleDesc, payload.active, payload.default, userId, payload.id];
+
+  return exec(query, params);
+};
+
+export { isRoleAvailable, getDefaultRole, deactivateRole, registerNewRole, getUserRoleById, getUserRoles, updateUserRoleById };

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ class AccountService extends Service {
     this.app.post(`${USERS_API}/setup/user-role`, routes.settingRoutes.registerUserRole);
     this.app.get(`${USERS_API}/setup/user-role`, routes.settingRoutes.getAllUserRoles);
     this.app.get(`${USERS_API}/setup/user-role/:roleId`, routes.settingRoutes.getUserRoleById);
+    this.app.put(`${USERS_API}/setup/user-role/:roleId`, routes.settingRoutes.updateUserRole);
 
     // User routes
     this.app.get(`${USERS_API}/user/:userId`, verifyUserId, routes.users.userInfo);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -116,6 +116,22 @@ components:
         - roleCode
         - roleDesc
 
+    updateUserRolePayload:
+      type: object
+      properties:
+        roleDesc:
+          type: string
+          description: Role Description
+          minLength: 1
+        default:
+          type: boolean
+          description: Is default user role
+        active:
+          type: boolean
+          description: Is active user role
+      required:
+        - roleDesc
+
     healthCheckData:
       title: Schema for Health Check Data
       type: object
@@ -329,10 +345,6 @@ components:
           type: boolean
         default:
           type: boolean
-        createdDate:
-          type: string
-        modifiedDate:
-          type: string
       required:
         - id
         - roleCode
@@ -520,6 +532,28 @@ components:
         statusCode:
           type: integer
           example: 200,
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          $ref: '#/components/schemas/registerUserRoleResponseData'
+
+    updateUserRoleResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+          example: 200
         type:
           type: string
           example: 'SUCCESS'
@@ -1012,6 +1046,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/getUserRoleByIdResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+    put:
+      operationId: updateUserRoleInfoById
+      summary: Update User Role Info by ID
+      description: An API to update the user role info for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/RoleIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/updateUserRolePayload'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/updateUserRoleResponse'
         '400':
           description: BAD_REQUEST
           content:

--- a/src/routes/system-setting-routes/getUserRoleById.route.js
+++ b/src/routes/system-setting-routes/getUserRoleById.route.js
@@ -3,7 +3,7 @@
 import { logger, buildApiResponse } from 'finance-lib';
 import controllers from '../../controllers/index.js';
 
-const log = logger('Router: get-all-user-roles');
+const log = logger('Router: get-user-role-by-id');
 const settingController = controllers.settingController;
 
 // API Function

--- a/src/routes/system-setting-routes/index.js
+++ b/src/routes/system-setting-routes/index.js
@@ -3,9 +3,11 @@
 import registerUserRole from './registerUserRole.route.js';
 import getAllUserRoles from './getAllUserRoles.route.js';
 import getUserRoleById from './getUserRoleById.route.js';
+import updateUserRole from './updateUserRole.route.js';
 
 export default {
   registerUserRole,
   getAllUserRoles,
   getUserRoleById,
+  updateUserRole,
 };

--- a/src/routes/system-setting-routes/updateUserRole.route.js
+++ b/src/routes/system-setting-routes/updateUserRole.route.js
@@ -1,0 +1,41 @@
+'use strict';
+
+import { logger, buildApiResponse } from 'finance-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: update-user-role');
+const settingController = controllers.settingController;
+
+// API Function
+const updateUserRole = async (req, res, next) => {
+  try {
+    log.info('User role info update for requested id operation initiated');
+    const roleId = req.params.roleId;
+    const payload = req.body;
+    const userId = req.user.id;
+
+    log.info('Call controller function to fetch user role details for requested id');
+    const roleDtl = await settingController.getRoleById(roleId);
+    if (!roleDtl.isValid) {
+      throw roleDtl;
+    }
+
+    log.info('Call controller function to update user role info');
+    const updatedRoleDtl = await settingController.updateUserRole(userId, roleId, roleDtl.data, payload);
+    if (!updatedRoleDtl.isValid) {
+      throw updatedRoleDtl;
+    }
+
+    log.success('User role info update operation completed successfully');
+    res.status(200).json(buildApiResponse(updatedRoleDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default updateUserRole;


### PR DESCRIPTION
Added updateUserRole API.
- User role description, default and active fields can be updated.
- User role description is a required property.
- If user provides default property as true, then we need to validate if the user role already default role or not. If not then we'll update the requested user role as default and make the existing default role as non-default.
- We'll also check if the payload consist of default as true and active as false, if so then it's a bad request as we cannot make the role as default and deactivate it.