### PR TITLE
Added get unassigned scopes API to the service

### DIFF
--- a/src/controllers/system-setting-controllers/index.js
+++ b/src/controllers/system-setting-controllers/index.js
@@ -8,6 +8,7 @@ import { verifyUserScopeExist, registerNewUserScope } from './registerUserScope.
 import { getScopeById, getAllUserScopes } from './getUserScope.controller.js';
 import { updateUserScope } from './updateUserScope.controller.js';
 import { deleteScope } from './deleteUserScope.controller.js';
+import { getUnassignedScopes } from './roleScope.controller.js';
 
 export default {
   verifyUserRoleExist,
@@ -22,4 +23,5 @@ export default {
   getAllUserScopes,
   updateUserScope,
   deleteScope,
+  getUnassignedScopes,
 };

--- a/src/controllers/system-setting-controllers/roleScope.controller.js
+++ b/src/controllers/system-setting-controllers/roleScope.controller.js
@@ -1,0 +1,54 @@
+'use strict';
+
+import { convertIdToPrettyString, convertPrettyStringToId, logger } from 'finance-lib';
+import { unassignedScopedByRoleId } from '../../db/index.js';
+
+const log = logger('Controller: get-role-scope');
+
+const getUnassignedScopes = async (roleId) => {
+  try {
+    log.info('Controller function to fetch unassigned user scopes process initiated');
+    roleId = convertPrettyStringToId(roleId);
+
+    log.info(`Call db query to fetch unassigned user scopes for provided role id: ${roleId}`);
+    let unassignedScopeDtl = await unassignedScopedByRoleId(roleId);
+    if (unassignedScopeDtl.rowCount === 0) {
+      log.info('No user scope available to display');
+      return {
+        status: 204,
+        message: 'No user scope found',
+        data: [],
+        isValid: true,
+      };
+    }
+
+    unassignedScopeDtl = unassignedScopeDtl.rows;
+    const scopeDtls = unassignedScopeDtl.map((scopeDtl) => {
+      return {
+        id: convertIdToPrettyString(scopeDtl.id),
+        scopeCode: scopeDtl.scope_cd,
+        scopeDesc: scopeDtl.scope_desc,
+      };
+    });
+
+    log.success('User scopes retrieval operation completed successfully');
+    return {
+      status: 200,
+      message: 'User scopes fetched successfully',
+      data: scopeDtls,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while fetching unassigned user scopes for requested role id from system');
+    return {
+      status: 500,
+      message: 'An error occurred while fetching unassigned user scopes for requested role id from system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { getUnassignedScopes };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -30,6 +30,7 @@ import {
   getUserScopes,
   updateUserScopeById,
   deleteUserScopeById,
+  unassignedScopedByRoleId,
 } from './system.db.js';
 
 export {
@@ -59,4 +60,5 @@ export {
   getUserScopes,
   updateUserScopeById,
   deleteUserScopeById,
+  unassignedScopedByRoleId,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -107,6 +107,16 @@ const deleteUserScopeById = async (userId, scopeId) => {
   return exec(query, params);
 };
 
+const unassignedScopedByRoleId = async (roleId) => {
+  const query = `SELECT ID, SCOPE_CD, SCOPE_DESC FROM USER_SCOPE
+    WHERE IS_DELETED = false AND ID NOT IN (
+      SELECT SCOPE_ID FROM ROLE_SCOPE WHERE ROLE_ID = ? AND IS_DELETED = false
+    );`;
+  const params = [roleId];
+
+  return exec(query, params);
+};
+
 export {
   isRoleAvailable,
   getDefaultRole,
@@ -122,4 +132,5 @@ export {
   getUserScopes,
   updateUserScopeById,
   deleteUserScopeById,
+  unassignedScopedByRoleId,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ class AccountService extends Service {
     this.app.get(`${USERS_API}/setup/user-scope/:scopeId`, routes.settingRoutes.getUserScopeById);
     this.app.put(`${USERS_API}/setup/user-scope/:scopeId`, routes.settingRoutes.updateUserScope);
     this.app.delete(`${USERS_API}/setup/user-scope/:scopeId`, routes.settingRoutes.deleteUserScope);
+    this.app.get(`${USERS_API}/setup/unassigned-scope/:roleId`, routes.settingRoutes.getUnassignedScopes);
 
     // User routes
     this.app.get(`${USERS_API}/user/:userId`, verifyUserId, routes.users.userInfo);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1508,3 +1508,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/unassigned-scope/{roleId}:
+    get:
+      operationId: getUnassignedUserScopeForRoleId
+      summary: Get User Scope Info unassigned to Role ID
+      description: An API to retrieve the user scope info unassigned for requested role ID.
+      parameters:
+        - $ref: '#/components/parameters/RoleIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getUserScopeResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'

--- a/src/routes/system-setting-routes/getUnassignedScopes.route.js
+++ b/src/routes/system-setting-routes/getUnassignedScopes.route.js
@@ -1,0 +1,40 @@
+'use strict';
+
+import { buildApiResponse, logger } from 'finance-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: get-unassigned-scopes');
+const settingController = controllers.settingController;
+
+// API Function
+const getUnassignedScopes = async (req, res, next) => {
+  try {
+    log.info('Get unassigned user scopes for requested role id operation initiated');
+    const roleId = req.params.roleId;
+
+    log.info('Call controller function to check if provided role id exists or not');
+    const roleDtl = await settingController.getRoleById(roleId);
+    if (!roleDtl.isValid) {
+      throw roleDtl;
+    }
+
+    log.info('Call controller function to fetch unassigned user scopes for role');
+    const scopeDtl = await settingController.getUnassignedScopes(roleId);
+    if (!scopeDtl.isValid) {
+      throw scopeDtl;
+    }
+    console.log(scopeDtl);
+
+    log.success('Unassigned user scopes fetched successfully');
+    res.status(200).json(buildApiResponse(scopeDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default getUnassignedScopes;

--- a/src/routes/system-setting-routes/index.js
+++ b/src/routes/system-setting-routes/index.js
@@ -10,6 +10,7 @@ import getAllUserScopes from './getAllUserScope.route.js';
 import getUserScopeById from './getUserScopeById.route.js';
 import updateUserScope from './updateUserScope.route.js';
 import deleteUserScope from './deleteUserScope.route.js';
+import getUnassignedScopes from './getUnassignedScopes.route.js';
 
 export default {
   registerUserRole,
@@ -22,4 +23,5 @@ export default {
   getUserScopeById,
   updateUserScope,
   deleteUserScope,
+  getUnassignedScopes,
 };


### PR DESCRIPTION
Added getUnassignedScopes API.
- The API will be used to fetch the scopes which are not assigned to the route.
- Based on the provided role id we'll be fetching the scope records which are not assigned to it.