### PR TITLE
Added register service config API to the service

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -2,8 +2,10 @@
 
 import userController from './user-controllers/index.js';
 import settingController from './system-setting-controllers/index.js';
+import serviceController from './service-setting-controllers/index.js';
 
 export default {
   userController,
   settingController,
+  serviceController,
 };

--- a/src/controllers/service-setting-controllers/getServiceConfig.controller.js
+++ b/src/controllers/service-setting-controllers/getServiceConfig.controller.js
@@ -1,0 +1,58 @@
+'use strict';
+
+import { convertIdToPrettyString, convertPrettyStringToId, convertToNativeTimeZone, logger } from 'finance-lib';
+import { getServiceById } from '../../db/index.js';
+
+const log = logger('Controller: get-service-config');
+
+const getServiceInfoById = async (svcId) => {
+  try {
+    log.info('Controller function to fetch service info by id process initiated');
+    svcId = convertPrettyStringToId(svcId);
+
+    log.info(`Call db query to fetch service details for provided id: ${svcId}`);
+    let configDtl = await getServiceById(svcId);
+    if (configDtl.rowCount === 0) {
+      log.error('Service configuration requested with the id does not exists in system');
+      return {
+        status: 404,
+        message: 'Service config not found',
+        data: [],
+        errors: [],
+        stack: 'getServiceById function call',
+        isValid: false,
+      };
+    }
+
+    configDtl = configDtl.rows[0];
+    configDtl = {
+      id: convertIdToPrettyString(configDtl.id),
+      microservice: configDtl.microservice,
+      environment: configDtl.environment,
+      protocol: configDtl.protocol,
+      port: configDtl.port,
+      createdDate: convertToNativeTimeZone(configDtl.created_date),
+      modifiedDate: convertToNativeTimeZone(configDtl.modified_date),
+    };
+
+    log.success('Requested service details fetched successfully');
+    return {
+      status: 200,
+      message: 'Service info fetched successfully',
+      data: configDtl,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while fetching service configuration for requested id from system');
+    return {
+      status: 500,
+      message: 'An error occurred while fetching service info for requested id from system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { getServiceInfoById };

--- a/src/controllers/service-setting-controllers/index.js
+++ b/src/controllers/service-setting-controllers/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+import { verifyConfigExist, registerNewConfig } from './registerServiceConfig.controller.js';
+import { getServiceInfoById } from './getServiceConfig.controller.js';
+
+export default { verifyConfigExist, registerNewConfig, getServiceInfoById };

--- a/src/controllers/service-setting-controllers/registerServiceConfig.controller.js
+++ b/src/controllers/service-setting-controllers/registerServiceConfig.controller.js
@@ -1,0 +1,75 @@
+'use strict';
+
+import { logger } from 'finance-lib';
+import { isServiceAvailable, registerNewService } from '../../db/index.js';
+import { getServiceInfoById } from './getServiceConfig.controller.js';
+
+const log = logger('Controller: register-service-config');
+
+const verifyConfigExist = async (payload) => {
+  try {
+    log.info('Controller for validating service configuration activated');
+    log.info('Call db query to validate if service already exists');
+    const configDtl = await isServiceAvailable(payload.microservice, payload.environment, payload.protocol);
+    if (configDtl.rowCount > 0) {
+      log.error('Service config already exists in system');
+      return {
+        status: 409,
+        message: 'Service config already exists',
+        data: configDtl.rows,
+        errors: [],
+        stack: 'verifyConfigExist function call',
+        isValid: false,
+      };
+    }
+
+    log.success('Service configuration verification completed successfully');
+    return {
+      status: 200,
+      message: 'Service config does not exists in system',
+      data: {},
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while validating new service configuration in system');
+    return {
+      status: 500,
+      message: 'An error occurred while validating service config in system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+const registerNewConfig = async (payload) => {
+  try {
+    log.info('Controller function to register new service config initiated');
+    log.info('Call db query to register new service config in system');
+    const newService = await registerNewService(payload);
+    const newServiceId = newService.rows[0].id;
+
+    const newServiceDtl = await getServiceInfoById(newServiceId);
+
+    log.success('New service configuration registered successfully in system');
+    return {
+      status: 201,
+      message: 'New service configuration registered',
+      data: newServiceDtl.data,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while registering new service configuration in system');
+    return {
+      status: 500,
+      message: 'An error occurred while registering service config in system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { verifyConfigExist, registerNewConfig };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -35,6 +35,9 @@ import {
   getMultipleScopesByIds,
   assignScopesToRole,
   unassignScopesToRole,
+  isServiceAvailable,
+  registerNewService,
+  getServiceById,
 } from './system.db.js';
 
 export {
@@ -69,4 +72,7 @@ export {
   getMultipleScopesByIds,
   assignScopesToRole,
   unassignScopesToRole,
+  isServiceAvailable,
+  registerNewService,
+  getServiceById,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -147,6 +147,30 @@ const unassignScopesToRole = async (userId, roleId, idsPlaceholder, scopeIdArr) 
   return exec(query, params);
 };
 
+const isServiceAvailable = async (microservice, environment, protocol) => {
+  const query = `SELECT ID FROM SVC_CONFIG WHERE MICROSERVICE = ? AND ENVIRONMENT = ? AND PROTOCOL = ? AND IS_DELETED = false;`;
+  const params = [microservice, environment, protocol];
+  return exec(query, params);
+};
+
+const registerNewService = async (payload) => {
+  const query = `INSERT INTO SVC_CONFIG (MICROSERVICE, ENVIRONMENT, PROTOCOL, PORT)
+    VALUES (?, ?, ?, ?)
+    RETURNING ID`;
+  const params = [payload.microservice, payload.environment, payload.protocol, payload.port];
+
+  return exec(query, params);
+};
+
+const getServiceById = async (svcId) => {
+  const query = `SELECT ID, MICROSERVICE, ENVIRONMENT, PROTOCOL, PORT, CREATED_DATE, MODIFIED_DATE
+    FROM SVC_CONFIG
+    WHERE ID = ? AND IS_DELETED = false;`;
+  const params = [svcId];
+
+  return exec(query, params);
+};
+
 export {
   isRoleAvailable,
   getDefaultRole,
@@ -167,4 +191,7 @@ export {
   getMultipleScopesByIds,
   assignScopesToRole,
   unassignScopesToRole,
+  isServiceAvailable,
+  registerNewService,
+  getServiceById,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,9 @@ class AccountService extends Service {
     this.app.get(`${USERS_API}/setup/unassigned-scope/:roleId`, routes.settingRoutes.getUnassignedScopes);
     this.app.put(`${USERS_API}/setup/assigned-scope/:roleId`, routes.settingRoutes.assignScopesToRole);
 
+    // Service routes
+    this.app.post(`${USERS_API}/setup/app-service`, routes.serviceRoutes.registerServiceConfig);
+
     // User routes
     this.app.get(`${USERS_API}/user/:userId`, verifyUserId, routes.users.userInfo);
     this.app.post(`${USERS_API}/user/logout`, routes.users.logoutUser);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -175,6 +175,34 @@ components:
       required:
         - scopes
 
+    registerAppServicePayload:
+      type: object
+      properties:
+        microservice:
+          type: string
+          description: Micro-service
+          minLength: 5
+        environment:
+          type: string
+          description: Environment
+          minLength: 2
+        protocol:
+          type: string
+          description: Protocol
+          minLength: 4
+          enum:
+            - HTTP
+            - HTTPS
+        port:
+          type: string
+          description: Port
+          minLength: 3
+      required:
+        - microservice
+        - environment
+        - protocol
+        - port
+
     healthCheckData:
       title: Schema for Health Check Data
       type: object
@@ -442,6 +470,31 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/getUserScopeResponseData'
+
+    registerAppServiceResponseData:
+      title: Schema for Fetching Service Configuration for Requested Service Response Data
+      type: object
+      properties:
+        id:
+          type: string
+        microservice:
+          type: string
+        environment:
+          type: string
+        protocol:
+          type: string
+        port:
+          type: string
+        createdDate:
+          type: string
+        modifiedDate:
+          type: string
+      required:
+        - id
+        - microservice
+        - environment
+        - protocol
+        - port
 
     emptyResponse:
       type: object
@@ -771,6 +824,28 @@ components:
         data:
           type: object
           $ref: '#/components/schemas/updateScopeAssignmentResponseData'
+
+    registerAppServiceResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+          example: 201
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          $ref: '#/components/schemas/registerAppServiceResponseData'
 
     noContentResponse:
       type: object
@@ -1670,6 +1745,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/app-service:
+    post:
+      operationId: RegisterServiceConfig
+      summary: Register New Service Configuration
+      description: An API to register new service configuration in system.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/registerAppServicePayload'
+      responses:
+        '201':
+          description: REQUEST_COMPLETED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerAppServiceResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '409':
+          description: CONFLICT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/userAlreadyExist'
         '500':
           description: INTERNAL_SERVER_ERROR
           content:

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,9 +3,11 @@
 import healthCheck from './healthCheck.route.js';
 import users from './user-routes/index.js';
 import settingRoutes from './system-setting-routes/index.js';
+import serviceRoutes from './service-setting-routes/index.js';
 
 export default {
   healthCheck,
   users,
   settingRoutes,
+  serviceRoutes,
 };

--- a/src/routes/service-setting-routes/index.js
+++ b/src/routes/service-setting-routes/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+import registerServiceConfig from './registerServiceConfig.route.js';
+
+export default {
+  registerServiceConfig,
+};

--- a/src/routes/service-setting-routes/registerServiceConfig.route.js
+++ b/src/routes/service-setting-routes/registerServiceConfig.route.js
@@ -1,0 +1,39 @@
+'use strict';
+
+import { logger, buildApiResponse } from 'finance-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: register-service-config');
+const serviceController = controllers.serviceController;
+
+// API Function
+const registerServiceConfig = async (req, res, next) => {
+  try {
+    log.info('Register service config request process initiated');
+    const payload = req.body;
+
+    log.info('Call controller function to validate if service config already exists');
+    const configExist = await serviceController.verifyConfigExist(payload);
+    if (!configExist.isValid) {
+      throw configExist;
+    }
+
+    log.info('Call controller function to register new service config in system');
+    const serviceDtl = await serviceController.registerNewConfig(payload);
+    if (!serviceDtl.isValid) {
+      throw serviceDtl;
+    }
+
+    log.success('User service registeration completed successfully');
+    res.status(201).json(buildApiResponse(serviceDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default registerServiceConfig;


### PR DESCRIPTION
Added registerServiceConfig API
- A new service configuration can be registered only if there's no existing record with the combination of microservice, environment and protocol.
- Once validated, we'll move further with registering new service configuration in system.
- Mandatory fields to be added are: microservice, environment, protocol and port.