### PR TITLE
Added delete dashboard header by id API to the service

### DIFF
--- a/src/controllers/dashboard-controllers/deleteDashboardHeader.controller.js
+++ b/src/controllers/dashboard-controllers/deleteDashboardHeader.controller.js
@@ -1,0 +1,66 @@
+'use strict';
+
+import { convertPrettyStringToId, logger } from 'common-node-lib';
+import { setupByHeaderId, deleteHeaderById } from '../../db/index.js';
+import { getHeaderInfoById } from './getDashboardHeader.controller.js';
+
+const log = logger('Controller: delete-dashboard-header');
+
+const deleteHeader = async (userId, headerId, headerDtl) => {
+  try {
+    log.info('Controller function to delete dashboard header from system process initiated');
+    headerId = convertPrettyStringToId(headerId);
+    userId = convertPrettyStringToId(userId);
+
+    if (headerDtl.core) {
+      log.error('Cannot delete the core dashboard header');
+      return {
+        status: 400,
+        message: 'Core dashboard header cannot be deleted',
+        data: [],
+        errors: [],
+        stack: 'deleteHeader function call',
+        isValid: false,
+      };
+    }
+
+    log.info('Call db query to check if any setup assigned to the header');
+    const setupRecords = await setupByHeaderId(headerId);
+    if (setupRecords.rowCount > 0) {
+      log.error('Cannot delete dashboard headers with setup assigned');
+      return {
+        status: 400,
+        message: 'Dashboard header with assigned setups cannot be deleted',
+        data: [],
+        errors: [],
+        stack: 'deleteHeader function call',
+        isValid: false,
+      };
+    }
+
+    log.info('Call db query to soft delete the dashboard header from system');
+    await deleteHeaderById(userId, headerId);
+    let deletedHeaderDtl = await getHeaderInfoById(headerId, true);
+    deletedHeaderDtl = deletedHeaderDtl.data;
+
+    log.success('Dashboard header deletion operation completed successfully');
+    return {
+      status: 200,
+      message: 'Dashboard header info deleted successfully',
+      data: deletedHeaderDtl,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while deleting header from system');
+    return {
+      status: 500,
+      message: 'An error occurred while deleting header from system',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { deleteHeader };

--- a/src/controllers/dashboard-controllers/index.js
+++ b/src/controllers/dashboard-controllers/index.js
@@ -7,6 +7,7 @@ import { verifyCategoryExist, registerNewDashboardCategory } from './registerDas
 import { getCategoryInfoById, getAllCategory } from './getDashboardCategory.controller.js';
 import { updateCategory } from './updateDashboardCategory.controller.js';
 import { deleteHeaderCategory } from './deleteCategory.controller.js';
+import { deleteHeader } from './deleteDashboardHeader.controller.js';
 
 export default {
   verifyHeaderExist,
@@ -20,4 +21,5 @@ export default {
   getAllCategory,
   updateCategory,
   deleteHeaderCategory,
+  deleteHeader,
 };

--- a/src/db/dashboard.db.js
+++ b/src/db/dashboard.db.js
@@ -89,6 +89,18 @@ const deleteCategoryById = async (userId, categoryId) => {
   return exec(query, params);
 };
 
+const setupByHeaderId = async (headerId) => {
+  const query = `SELECT ID FROM DASHBOARD_SETUP WHERE HEADER_ID = ? AND IS_DELETED = false;`;
+  const params = [headerId];
+  return exec(query, params);
+};
+
+const deleteHeaderById = async (userId, headerId) => {
+  const query = `UPDATE DASHBOARD_SETUP_HEADER SET IS_DELETED = true, MODIFIED_BY = ? WHERE ID = ?`;
+  const params = [userId, headerId];
+  return exec(query, params);
+};
+
 export {
   isDashboardHeaderAvailable,
   registerNewHeader,
@@ -101,4 +113,6 @@ export {
   getAllCategoryInfo,
   updateCategoryInfo,
   deleteCategoryById,
+  setupByHeaderId,
+  deleteHeaderById,
 };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -62,6 +62,8 @@ import {
   getAllCategoryInfo,
   updateCategoryInfo,
   deleteCategoryById,
+  setupByHeaderId,
+  deleteHeaderById,
 } from './dashboard.db.js';
 
 export {
@@ -120,4 +122,6 @@ export {
   getAllCategoryInfo,
   updateCategoryInfo,
   deleteCategoryById,
+  setupByHeaderId,
+  deleteHeaderById,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class AccountService extends Service {
     this.app.get(`${USERS_API}/dashboard/header`, verifyScope('SETUP.V'), routes.dashboardRoutes.getDashboardHeader);
     this.app.get(`${USERS_API}/dashboard/header/:headerId`, verifyScope('SETUP.V'), routes.dashboardRoutes.getDashboardHeader);
     this.app.put(`${USERS_API}/dashboard/header/:headerId`, verifyScope('SETUP.U'), routes.dashboardRoutes.updateDashboardHeader);
-    // this.app.delete(`${USERS_API}/dashboard/header/:headerId`, verifyScope('SETUP.D'), );                -- Delete Dashboard Header for provided header ID
+    this.app.delete(`${USERS_API}/dashboard/header/:headerId`, verifyScope('SETUP.D'), routes.dashboardRoutes.deleteDashboardHeader);
 
     // Dashboard Setup routes
     this.app.post(`${USERS_API}/dashboard/category`, verifyScope('SETUP.U'), routes.dashboardRoutes.registerDashboardCategory);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3174,6 +3174,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
 
+    delete:
+      operationId: deleteDashboardHeaderById
+      summary: Delete Dashboard Header by ID
+      description: An API to delete the dashboard header for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/HeaderIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerDashboardHeaderResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
   /dashboard/category:
     post:
       operationId: registerDashboardCategoryRoute

--- a/src/routes/dashboard-routes/deleteDashboardById.route.js
+++ b/src/routes/dashboard-routes/deleteDashboardById.route.js
@@ -1,0 +1,40 @@
+'use strict';
+
+import { logger, buildApiResponse } from 'common-node-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: delete-header-by-id');
+const dashboardController = controllers.dashboardController;
+
+// API Function
+const deleteDashboardHeader = async (req, res, next) => {
+  try {
+    log.info('Dashboard header deletion operation initiated');
+    const headerId = req.params.headerId;
+    const userId = req.user.id;
+
+    log.info('Call controller function to validate if header for requested id exists');
+    const headerDtl = await dashboardController.getHeaderInfoById(headerId);
+    if (!headerDtl.isValid) {
+      throw headerDtl;
+    }
+
+    log.info('Call controller function to delete the header info');
+    const deletedHeaderDtl = await dashboardController.deleteHeader(userId, headerId, headerDtl.data);
+    if (!deletedHeaderDtl.isValid) {
+      throw deletedHeaderDtl;
+    }
+
+    log.success('Dashboard header deletion operation completed successfully');
+    res.status(200).json(buildApiResponse(deletedHeaderDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default deleteDashboardHeader;

--- a/src/routes/dashboard-routes/index.js
+++ b/src/routes/dashboard-routes/index.js
@@ -7,6 +7,7 @@ import registerDashboardCategory from './registerDashboardCategory.route.js';
 import getDashboardCategory from './getDashboardCategory.route.js';
 import updateDashboardCategory from './updateDashboardCategoryById.route.js';
 import deleteHeaderCategory from './deleteCategoryById.route.js';
+import deleteDashboardHeader from './deleteDashboardById.route.js';
 
 export default {
   registerDashboardHeader,
@@ -16,4 +17,5 @@ export default {
   getDashboardCategory,
   updateDashboardCategory,
   deleteHeaderCategory,
+  deleteDashboardHeader,
 };


### PR DESCRIPTION
Added deleteDashboardHeaderByID API
- Process will start by validating if the requested header for the provided id exists.
- If exists then we'll validate if the record core value is set to true or not. If yes then return 400 error.
- Further check if header has any setup record assigned. If yes then return 400 error. The record with active setups cannot be deleted.
- If all these validations are successful then proceed with soft deleting the record.